### PR TITLE
Add support for global atomic transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'sqla-fancy-core'
-version = '1.1.2'
+version = '1.2.0'
 description = 'SQLAlchemy core, but fancier'
 readme = 'README.md'
 requires-python = ">=3.7"

--- a/sqla_fancy_core/__init__.py
+++ b/sqla_fancy_core/__init__.py
@@ -1,5 +1,11 @@
 """SQLAlchemy core, but fancier."""
 
 from sqla_fancy_core.factories import TableFactory  # noqa
-from sqla_fancy_core.wrappers import FancyEngineWrapper, AsyncFancyEngineWrapper, fancy  # noqa
+from sqla_fancy_core.wrappers import (  # noqa
+    FancyEngineWrapper,
+    AsyncFancyEngineWrapper,
+    fancy,
+    FancyError,
+    AtomicContextError,
+)
 from sqla_fancy_core.decorators import transact, Inject  # noqa

--- a/tests/test_async_atomic.py
+++ b/tests/test_async_atomic.py
@@ -1,0 +1,96 @@
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from sqla_fancy_core import TableFactory, fancy
+from sqla_fancy_core.wrappers import AtomicContextError
+
+
+tf = TableFactory()
+
+
+class Counter:
+    id = tf.auto_id()
+    Table = tf("counter")
+
+
+q_insert = sa.insert(Counter.Table)
+q_count = sa.select(sa.func.count()).select_from(Counter.Table)
+
+
+@pytest_asyncio.fixture
+async def fancy_engine():
+    eng = fancy(create_async_engine("sqlite+aiosqlite:///:memory:"))
+    async with eng.engine.begin() as conn:
+        await conn.run_sync(tf.metadata.create_all)
+    try:
+        yield eng
+    finally:
+        async with eng.engine.begin() as conn:
+            await conn.run_sync(tf.metadata.drop_all)
+        await eng.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ax_raises_outside_atomic(fancy_engine):
+    with pytest.raises(AtomicContextError):
+        await fancy_engine.ax(q_count)
+
+
+@pytest.mark.asyncio
+async def test_ax_inside_atomic_commits_on_exit(fancy_engine):
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 0
+    async with fancy_engine.atomic() as conn:
+        await fancy_engine.ax(q_insert)
+        await fancy_engine.ax(q_insert)
+        assert (await fancy_engine.ax(q_count)).scalar_one() == 2
+        assert conn.in_transaction() is True
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 2
+
+
+@pytest.mark.asyncio
+async def test_nested_atomic_reuses_same_connection(fancy_engine):
+    async with fancy_engine.atomic() as conn1:
+        async with fancy_engine.atomic() as conn2:
+            assert conn1 is conn2
+            await fancy_engine.ax(q_insert)
+            assert (await fancy_engine.ax(q_count)).scalar_one() == 1
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_tx_uses_atomic_connection_when_inside(fancy_engine):
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 0
+    async with fancy_engine.atomic() as conn:
+        await fancy_engine.tx(None, q_insert)
+        assert (await fancy_engine.tx(conn, q_count)).scalar_one() == 1
+        assert conn.in_transaction() is True
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_atomic_rollback_on_exception(fancy_engine):
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 0
+    with pytest.raises(RuntimeError):
+        async with fancy_engine.atomic():
+            await fancy_engine.ax(q_insert)
+            assert (await fancy_engine.ax(q_count)).scalar_one() == 1
+            raise RuntimeError("boom")
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 0
+
+
+@pytest.mark.asyncio
+async def test_atx_outside_atomic_commits(fancy_engine):
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 0
+    await fancy_engine.atx(q_insert)
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_atx_inside_atomic_reuses_same_connection(fancy_engine):
+    async with fancy_engine.atomic() as conn:
+        await fancy_engine.atx(q_insert)
+        assert (await fancy_engine.ax(q_count)).scalar_one() == 1
+        assert conn.in_transaction() is True
+    assert (await fancy_engine.x(None, q_count)).scalar_one() == 1

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,0 +1,92 @@
+import pytest
+import sqlalchemy as sa
+
+from sqla_fancy_core import TableFactory, fancy
+from sqla_fancy_core.wrappers import AtomicContextError
+
+tf = TableFactory()
+
+
+class Counter:
+    id = tf.auto_id()
+    Table = tf("counter")
+
+
+q_insert = sa.insert(Counter.Table)
+q_count = sa.select(sa.func.count()).select_from(Counter.Table)
+
+
+@pytest.fixture
+def fancy_engine():
+    eng = fancy(sa.create_engine("sqlite:///:memory:"))
+    tf.metadata.create_all(eng.engine)
+    try:
+        yield eng
+    finally:
+        tf.metadata.drop_all(eng.engine)
+        eng.engine.dispose()
+
+
+def test_ax_raises_outside_atomic(fancy_engine):
+    with pytest.raises(AtomicContextError):
+        fancy_engine.ax(q_count)
+
+
+def test_ax_inside_atomic_commits_on_exit(fancy_engine):
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+    with fancy_engine.atomic() as conn:
+        # multiple ax() calls share the same connection
+        fancy_engine.ax(q_insert)
+        fancy_engine.ax(q_insert)
+        # visibility within the same transaction
+        assert fancy_engine.ax(q_count).scalar_one() == 2
+        assert conn.in_transaction() is True
+    # committed after context exit
+    assert fancy_engine.x(None, q_count).scalar_one() == 2
+
+
+def test_nested_atomic_reuses_same_connection(fancy_engine):
+    with fancy_engine.atomic() as conn1:
+        with fancy_engine.atomic() as conn2:
+            assert conn1 is conn2
+            fancy_engine.ax(q_insert)
+            assert fancy_engine.ax(q_count).scalar_one() == 1
+    assert fancy_engine.x(None, q_count).scalar_one() == 1
+
+
+def test_tx_uses_atomic_connection_when_inside(fancy_engine):
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+    with fancy_engine.atomic() as conn:
+        # tx(None, ...) should reuse the atomic connection/transaction
+        fancy_engine.tx(None, q_insert)
+        # The outer connection should see the uncommitted row
+        assert fancy_engine.tx(conn, q_count).scalar_one() == 1
+        assert conn.in_transaction() is True
+    # committed at outer context exit
+    assert fancy_engine.x(None, q_count).scalar_one() == 1
+
+
+def test_atomic_rollback_on_exception(fancy_engine):
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+    with pytest.raises(RuntimeError):
+        with fancy_engine.atomic():
+            fancy_engine.ax(q_insert)
+            assert fancy_engine.ax(q_count).scalar_one() == 1
+            raise RuntimeError("boom")
+    # rolled back
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+
+def test_atx_outside_atomic_commits(fancy_engine):
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+    fancy_engine.atx(q_insert)
+    assert fancy_engine.x(None, q_count).scalar_one() == 1
+
+
+def test_atx_inside_atomic_reuses_same_connection(fancy_engine):
+    with fancy_engine.atomic() as conn:
+        fancy_engine.atx(q_insert)
+        # Same transactional visibility within the atomic connection
+        assert fancy_engine.ax(q_count).scalar_one() == 1
+        assert conn.in_transaction() is True
+    assert fancy_engine.x(None, q_count).scalar_one() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -2968,7 +2968,7 @@ wheels = [
 
 [[package]]
 name = "sqla-fancy-core"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "sqlalchemy" },


### PR DESCRIPTION
This adds support for the following syntax:

```python
with fancy_engine.atomic():
    fancy_engine.ax(qry)   # Uses the global transaction
    fancy_engine.atx(qry)  # Uses the global transaction

fancy_engine.atx(qry)  # Creates a new transaction
```