### PR TITLE
Non atomic ops should use available atomic context

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Simplify running queries with or without explicit connection or transaction. The
 
 ### Execute query without transaction
 
-- `x(conn, query)`: Execute query with optional connection (reuses `non_atomic()` context if available, else creates new)
+- `x(conn, query)`: Execute query with optional connection (reuses `non_atomic()` or `atomic()` context if available, else creates new)
 - `non_atomic()`: Context manager for non-transactional connections (allows manual transaction control)
-- `nax(query)`: Execute inside `non_atomic()` context or create a new connection
+- `nax(query)`: Execute inside `non_atomic()` or `atomic()` context or create a new connection
 
 ### Basic Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'sqla-fancy-core'
-version = '3.0.1'
+version = '4.0.0'
 description = 'A collection of type-safe, async friendly, and un-opinionated enhancements to SQLAlchemy Core that works well with mordern web servers.'
 readme = 'README.md'
 requires-python = ">=3.10"

--- a/sqla_fancy_core/errors.py
+++ b/sqla_fancy_core/errors.py
@@ -30,3 +30,10 @@ class UnsupportedEngineTypeError(TypeError, FancyError):
 
     def __init__(self) -> None:
         super().__init__("Unsupported engine type provided to the decorator")
+
+
+class AtomicInsideNonAtomicError(FancyError):
+    """Error raised when atomic() is called inside a non_atomic() context."""
+
+    def __init__(self) -> None:
+        super().__init__("atomic() cannot be called inside a non_atomic() context")

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from sqla_fancy_core import TableBuilder, fancy
-from sqla_fancy_core.errors import AtomicContextError
+from sqla_fancy_core.errors import AtomicContextError, NotInTransactionError
 
 tb = TableBuilder()
 
@@ -122,7 +122,9 @@ def test_atomic_isolation_from_other_connections(fancy_engine_postgres):
         fancy_engine_postgres.ax(q_insert)
         assert fancy_engine_postgres.ax(q_count).scalar_one() == 1
         # A new connection outside the atomic context shouldn't see the uncommitted insert
-        assert fancy_engine_postgres.x(None, q_count).scalar_one() == 0
+        # Create an explicit new connection to test isolation
+        with fancy_engine_postgres.engine.connect() as new_conn:
+            assert fancy_engine_postgres.x(new_conn, q_count).scalar_one() == 0
 
     # After commit, new connections should see it
     assert fancy_engine_postgres.x(None, q_count).scalar_one() == 1
@@ -157,3 +159,78 @@ def test_atomic_with_explicit_rollback_raises_exception(fancy_engine):
             raise RuntimeError("explicit rollback then error")
 
     assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+
+def test_ax_raises_not_in_transaction_after_commit(fancy_engine):
+    """Test that ax() raises NotInTransactionError when connection is not in transaction."""
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+    with fancy_engine.atomic() as conn:
+        fancy_engine.ax(q_insert)
+        assert fancy_engine.ax(q_count).scalar_one() == 1
+        # Manually commit the transaction
+        conn.commit()
+        # Now ax() should raise NotInTransactionError
+        with pytest.raises(NotInTransactionError):
+            fancy_engine.ax(q_insert)
+
+
+def test_atx_raises_not_in_transaction_after_commit(fancy_engine):
+    """Test that atx() raises NotInTransactionError when connection is not in transaction."""
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+    with fancy_engine.atomic() as conn:
+        fancy_engine.atx(q_insert)
+        assert fancy_engine.atx(q_count).scalar_one() == 1
+        # Manually commit the transaction
+        conn.commit()
+        # Now atx() should raise NotInTransactionError
+        with pytest.raises(NotInTransactionError):
+            fancy_engine.atx(q_insert)
+
+
+def test_tx_raises_not_in_transaction_with_committed_connection(fancy_engine):
+    """Test that tx() raises NotInTransactionError when passed a non-transactional connection."""
+    # Create a connection without a transaction
+    with fancy_engine.engine.connect() as conn:
+        # Connection exists but is not in a transaction
+        with pytest.raises(NotInTransactionError):
+            fancy_engine.tx(conn, q_insert)
+
+
+def test_ax_works_after_nested_atomic_with_same_connection(fancy_engine):
+    """Test that ax() continues to work in nested atomic contexts using the same connection."""
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+    with fancy_engine.atomic() as conn1:
+        fancy_engine.ax(q_insert)
+        assert conn1.in_transaction() is True
+        
+        with fancy_engine.atomic() as conn2:
+            # Same connection should be reused
+            assert conn1 is conn2
+            assert conn2.in_transaction() is True
+            fancy_engine.ax(q_insert)
+            assert fancy_engine.ax(q_count).scalar_one() == 2
+        
+        # Still in transaction after nested context
+        assert conn1.in_transaction() is True
+        fancy_engine.ax(q_insert)
+        assert fancy_engine.ax(q_count).scalar_one() == 3
+
+    # All committed
+    assert fancy_engine.x(None, q_count).scalar_one() == 3
+
+
+def test_atomic_rejects_ax_after_rollback(fancy_engine):
+    """Test that ax() raises NotInTransactionError after explicit rollback."""
+    assert fancy_engine.x(None, q_count).scalar_one() == 0
+
+    with fancy_engine.atomic() as conn:
+        fancy_engine.ax(q_insert)
+        assert fancy_engine.ax(q_count).scalar_one() == 1
+        # Explicitly rollback
+        conn.rollback()
+        # Connection is no longer in transaction
+        with pytest.raises(NotInTransactionError):
+            fancy_engine.ax(q_insert)

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "sqla-fancy-core"
-version = "3.0.1"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "sqlalchemy" },


### PR DESCRIPTION
- atomic() inside non_atomic() should not be possible.
- non_atomic() inside atomic() is possible and uses the atomic() connection only.